### PR TITLE
Convert error object to string before logging.

### DIFF
--- a/openvisualizer/JRC/JRC.py
+++ b/openvisualizer/JRC/JRC.py
@@ -204,8 +204,8 @@ class coapServer(eventBusClient.eventBusClient):
         # UDP
         udplen = len(data) + 8
 
-        udp = u.int2buf(self.coapClient.udpPort,2)  # src port
-        udp += u.int2buf(sender[1],2) # dest port
+        udp = u.int2buf(sender[1], 2)  # src port
+        udp += u.int2buf(self.coapClient.udpPort, 2)  # dest port
         udp += [udplen >> 8, udplen & 0xff]  # length
         udp += [0x00, 0x00]  # checksum
         udp += data
@@ -226,7 +226,7 @@ class coapServer(eventBusClient.eventBusClient):
             dst=dstIpv6Address,
             length=[0x00, 0x00] + udp[4:6],
             nh=[0x00, 0x00, 0x00, 17], # UDP as next header
-            payload=data,
+            payload=udp,
         )
 
         # IPv6

--- a/openvisualizer/openTun/openTun.py
+++ b/openvisualizer/openTun/openTun.py
@@ -118,7 +118,7 @@ class OpenTun(eventBusClient.eventBusClient):
                     # Give thread some time to exit
                     time.sleep(0.05)
                 except Exception as err:
-                    log.error('Unable to send UDP to close tunReadThread: {0}'.join(err))
+                    log.error('Unable to send UDP to close tunReadThread: {0}'.join(str(err)))
     
     #======================== private =========================================
     


### PR DESCRIPTION
This fix prevents an error in the console, preventing clean OV shutdown.