### PR TITLE
OV-18: Add support for P2P traffic in the mesh.

### DIFF
--- a/openvisualizer/openLbr/openLbr.py
+++ b/openvisualizer/openLbr/openLbr.py
@@ -422,9 +422,14 @@ class OpenLbr(eventBusClient.eventBusClient):
                 return
 
             # assemble the packet and dispatch it again as nobody answer
-            ipv6pkt=self.reassemble_ipv6_packet(ipv6dic)
+            ipv6pkt = self.reassemble_ipv6_packet(ipv6dic)
 
-            self.dispatch('v6ToInternet',ipv6pkt)
+            if self.networkPrefix == ipv6dic['dst_addr'][:8]:
+                # dispatch to mesh
+                self.dispatch('v6ToMesh', ipv6pkt)
+            else:
+                # dispatch to Internet
+                self.dispatch('v6ToInternet',ipv6pkt)
 
         except (ValueError,IndexError,NotImplementedError) as err:
             log.error(err)


### PR DESCRIPTION
This is a simple PR that adds support for packets originating from the mesh but that are destined for the mesh.