### PR TITLE
Reduce CPU load when it's used against OpenTestbed

### DIFF
--- a/bin/openVisualizerApp.py
+++ b/bin/openVisualizerApp.py
@@ -126,8 +126,13 @@ class OpenVisualizerApp(object):
             eventLogger.eventLogger(ms) for ms in self.moteStates
         ]
 
-        self.remoteConnectorServer = remoteConnectorServer.remoteConnectorServer()
-
+        if self.testbedmotes:
+            # at least, when we use OpenTestbed, we don't need
+            # Rover. Don't instantiate remoteConnectorServer which
+            # consumes a lot of CPU.
+            self.remoteConnectorServer = None
+        else:
+            self.remoteConnectorServer = remoteConnectorServer.remoteConnectorServer()
 
         # boot all emulated motes, if applicable
         if self.simulatorMode:

--- a/bin/openVisualizerWeb.py
+++ b/bin/openVisualizerWeb.py
@@ -138,9 +138,13 @@ class OpenVisualizerWeb(eventBusClient.eventBusClient,Cmd):
         self.websrv.route(path='/topology/connections',   method='DELETE',callback=self._topologyConnectionsDelete)
         self.websrv.route(path='/topology/route',         method='GET',   callback=self._topologyRouteRetrieve)
         self.websrv.route(path='/static/<filepath:path>',                 callback=self._serverStatic)
-        self.websrv.route(path='/rovers',                                 callback=self._showrovers)
-        self.websrv.route(path='/updateroverlist/:updatemsg',             callback=self._updateRoverList)
-        self.websrv.route(path='/motesdiscovery/:srcip',                  callback=self._motesDiscovery)
+
+        # activate these routes only if remoteConnectorServer is available
+        if self._isRoverMode():
+            self.websrv.route(path='/rovers',                                 callback=self._showrovers)
+            self.websrv.route(path='/updateroverlist/:updatemsg',             callback=self._updateRoverList)
+            self.websrv.route(path='/motesdiscovery/:srcip',                  callback=self._motesDiscovery)
+
     def _isRoverMode(self):
         return self.app.remoteConnectorServer is not None
 
@@ -156,7 +160,7 @@ class OpenVisualizerWeb(eventBusClient.eventBusClient,Cmd):
         tmplData = {
             'myifdict'  : myifdict,
             'roverMotes' : self.roverMotes,
-            'roverMode' : True,
+            'roverMode' : self._isRoverMode()
         }
         return tmplData
 
@@ -238,7 +242,7 @@ class OpenVisualizerWeb(eventBusClient.eventBusClient,Cmd):
         tmplData = {
             'motelist'       : motelist,
             'requested_mote' : moteid if moteid else 'none',
-            'roverMode'      : True,
+            'roverMode'      : self._isRoverMode()
         }
         return tmplData
 
@@ -320,7 +324,7 @@ class OpenVisualizerWeb(eventBusClient.eventBusClient,Cmd):
         for periodic updates of event list.
         '''
         tmplData = self._getEventData().copy()
-        tmplData['roverMode'] = True
+        tmplData['roverMode'] = self._isRoverMode()
         return tmplData
 
     def _showDAG(self):
@@ -329,7 +333,7 @@ class OpenVisualizerWeb(eventBusClient.eventBusClient,Cmd):
 
     @view('connectivity.tmpl')
     def _showConnectivity(self):
-        return {'roverMode' : True}
+        return {'roverMode' : self._isRoverMode()}
 
     def _showMotesConnectivity(self):
         states,edges = self.app.getMotesConnectivity()
@@ -337,7 +341,7 @@ class OpenVisualizerWeb(eventBusClient.eventBusClient,Cmd):
 
     @view('routing.tmpl')
     def _showRouting(self):
-        return {'roverMode' : True}
+        return {'roverMode' : self._isRoverMode()}
 
     @view('topology.tmpl')
     def _topologyPage(self):
@@ -345,7 +349,7 @@ class OpenVisualizerWeb(eventBusClient.eventBusClient,Cmd):
         Retrieve the HTML/JS page.
         '''
 
-        return {'roverMode' : True}
+        return {'roverMode' : self._isRoverMode()}
 
     def _topologyData(self):
         '''

--- a/bin/openVisualizerWeb.py
+++ b/bin/openVisualizerWeb.py
@@ -141,6 +141,8 @@ class OpenVisualizerWeb(eventBusClient.eventBusClient,Cmd):
         self.websrv.route(path='/rovers',                                 callback=self._showrovers)
         self.websrv.route(path='/updateroverlist/:updatemsg',             callback=self._updateRoverList)
         self.websrv.route(path='/motesdiscovery/:srcip',                  callback=self._motesDiscovery)
+    def _isRoverMode(self):
+        return self.app.remoteConnectorServer is not None
 
     @view('rovers.tmpl')
     def _showrovers(self):

--- a/openvisualizer/eventLogger/eventLogger.py
+++ b/openvisualizer/eventLogger/eventLogger.py
@@ -33,13 +33,13 @@ class eventLogger(threading.Thread):
     #======================== thread ==========================================
     
     def run(self):
-        
+
+        # to record mote status to file, uncomment the following code
+        '''
         while True:
             # by default, don't write to local files
             pass
-            
-            # to record mote status to file, uncomment the following code
-            '''
+
             with open(self.logfile,'a') as f:
                 for key, value in self.moteState.state.items():
                     self.output[key] = value._toDict()["data"]
@@ -54,8 +54,8 @@ class eventLogger(threading.Thread):
                 f.write(str(self.moteState.moteConnector.parser.parserInfo.errorinfo)+'\n')
                 
             time.sleep(2)
-            '''
-            
+        '''
+
     #======================== public ==========================================
     
     #======================== private =========================================


### PR DESCRIPTION
Mainly, there are two changes:

* prevent an infinite loop (for nothing)
* don't instantiate `remoteConnectorServer`, which seems to consume a lot of CPU (for nothing), when `--opentestbed` is specified

In addition, when `--opentestbed` is specified, "Rovers" menu will not be shown in the navigation bar like this:

![navbar](https://user-images.githubusercontent.com/1230923/59701589-3cd3b300-91f6-11e9-8041-84dacbb42da7.png)

Here is a screenshot of a case without `--opentestbed`:

![navbar-rover](https://user-images.githubusercontent.com/1230923/59701584-3a715900-91f6-11e9-8ca4-ce1ff895f9af.png)


