### PR TITLE
Fixes conflicting pylint versions between openwsn-coap and OV

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ netifaces
 yappi
 intelhex==2.1
 openwsn-coap
-pylint==1.6.0
+pylint
 pycryptodome
 cbor
 hkdf


### PR DESCRIPTION
OpenWSN-coap uses the latest version of pylint (1.9.5) while OV is using version 1.6.0. This leads to a conflict when installing the necessary python packages with
`pip install -r requirements.txt`

Solution: also use the latest pylint version with openvisualizer