### PR TITLE
 SW-319. improve iotlab support

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,25 @@ Otherwise you need to pass your username and password as additional parameters:
 (venv)  $ openv-server --iotlab-motes m3-10 m3-11 --user <USERNAME> --password <PASSWORD>
 ```
 
+If the ssh key used to authenticate over iot-lab is not found you can specify its
+location with `--iotlab_key_file` option:
+
+```bash
+(venv)  $ openv-server --iotlab-motes m3-10 m3-11 --iotlab-key-file=<key file path>
+```
+
+This can be useful when running as superuser (required by --opentun).
+
+##### Iot-LAB A8-M3
+
+For iotlab-a8-m3 there is no default TCP port opened, so OpenVisualizer will take
+care of opening one over the specified baudrates so only for Iot-LAB A8-M3 the
+baudrate must also be specified, e.g:
+
+    ```bash
+    (venv) $ openv-server --iotlab-motes a8-4.grenoble.iot-lab.info a8-5.grenoble.iot-lab.info --baudrate 500000
+    ```
+
 ### OpenTestBed <a name="opentestbed"></a>
 
 Running the _OpenVisualizer Server_ as a frontend for the OpenTestBed is as simple as:

--- a/openvisualizer/main.py
+++ b/openvisualizer/main.py
@@ -119,7 +119,8 @@ class OpenVisualizerServer(SimpleXMLRPCServer, EventBusClient):
     def __init__(self, host, port, simulator_mode, debug, vcdlog,
                  use_page_zero, sim_topology, testbed_motes, mqtt_broker,
                  opentun, fw_path, auto_boot, root, port_mask, baudrate,
-                 topo_file, iotlab_motes, iotlab_passwd, iotlab_user):
+                 topo_file, iotlab_motes, iotlab_passwd, iotlab_user,
+                 iotlab_key_file, iotlab_key_pas):
 
         # store params
         self.host = host
@@ -212,7 +213,9 @@ class OpenVisualizerServer(SimpleXMLRPCServer, EventBusClient):
                 iotlab_motes=iotlab_motes,
                 iotlab_user=iotlab_user,
                 iotlab_passwd=iotlab_passwd,
-            )
+                iotlab_key_file=iotlab_key_file,
+                iotlab_key_pas=iotlab_key_pas,
+                )
         elif testbed_motes:
             motes_finder = testbedmoteprobe.OpentestbedMoteFinder(mqtt_broker)
             mote_list = motes_finder.get_opentestbed_motelist()
@@ -698,7 +701,18 @@ def _add_iotlab_parser_args(parser):
         help='comma-separated list of IoT-LAB motes (e.g. "wsn430-9,wsn430-34,wsn430-3")'
     )
     common.add_auth_arguments(iotlab_parser, False)
-
+    iotlab_parser.add_argument(
+        '--iotlab-key-file',
+        default='~/.ssh/id_rsa',
+        type=str,
+        help='Location of ssh key registered on iotlab'
+    )
+    iotlab_parser.add_argument(
+        '--iotlab-key-pas',
+        default='',
+        type=str,
+        help='If required ssh key file password'
+    )
 
 def _add_parser_args(parser):
     """ Adds arguments specific to the OpenVisualizer application """
@@ -949,6 +963,8 @@ def main():
         iotlab_motes=args.iotlab_motes,
         iotlab_user=args.username,
         iotlab_passwd=args.password,
+        iotlab_key_file=args.iotlab_key_file,
+        iotlab_key_pas=args.iotlab_key_pas,
     )
 
     try:

--- a/openvisualizer/main.py
+++ b/openvisualizer/main.py
@@ -246,46 +246,46 @@ class OpenVisualizerServer(SimpleXMLRPCServer, EventBusClient):
         # set up RPC server
         try:
             SimpleXMLRPCServer.__init__(self, (self.host, self.port), allow_none=True, logRequests=False)
+
+            self.register_introspection_functions()
+
+            # register RPCs
+            self.register_function(self.shutdown)
+            self.register_function(self.get_mote_dict)
+            self.register_function(self.boot_motes)
+            self.register_function(self.set_root)
+            self.register_function(self.get_mote_state)
+            self.register_function(self.get_dagroot)
+            self.register_function(self.get_dag)
+            self.register_function(self.get_motes_connectivity)
+            self.register_function(self.get_wireshark_debug)
+            self.register_function(self.enable_wireshark_debug)
+            self.register_function(self.disable_wireshark_debug)
+            self.register_function(self.get_ebm_stats)
+            self.register_function(self.get_network_topology)
+            self.register_function(self.update_network_topology)
+            self.register_function(self.create_motes_connection)
+            self.register_function(self.update_motes_connection)
+            self.register_function(self.delete_motes_connection)
+            self.register_function(self.retrieve_routing_path)
+
+            # boot all simulated motes
+            if self.simulator_mode and self.auto_boot:
+                self.boot_motes(['all'])
+
+            # set a mote (hardware or emulated) as DAG root of the network
+            if self.root is not None:
+                if self.simulator_mode and self.auto_boot is False:
+                    log.warning("Cannot set root when motes are not booted! ")
+                else:
+                    log.info("Setting DAG root...")
+                    # make sure that the simulated motes are booted and the hardware motes have communicated there mote ID
+                    time.sleep(1.5)
+                    self.set_root(self.root)
         except Exception as e:
             log.critical(e)
             self.shutdown()
             return
-
-        self.register_introspection_functions()
-
-        # register RPCs
-        self.register_function(self.shutdown)
-        self.register_function(self.get_mote_dict)
-        self.register_function(self.boot_motes)
-        self.register_function(self.set_root)
-        self.register_function(self.get_mote_state)
-        self.register_function(self.get_dagroot)
-        self.register_function(self.get_dag)
-        self.register_function(self.get_motes_connectivity)
-        self.register_function(self.get_wireshark_debug)
-        self.register_function(self.enable_wireshark_debug)
-        self.register_function(self.disable_wireshark_debug)
-        self.register_function(self.get_ebm_stats)
-        self.register_function(self.get_network_topology)
-        self.register_function(self.update_network_topology)
-        self.register_function(self.create_motes_connection)
-        self.register_function(self.update_motes_connection)
-        self.register_function(self.delete_motes_connection)
-        self.register_function(self.retrieve_routing_path)
-
-        # boot all simulated motes
-        if self.simulator_mode and self.auto_boot:
-            self.boot_motes(['all'])
-
-        # set a mote (hardware or emulated) as DAG root of the network
-        if self.root is not None:
-            if self.simulator_mode and self.auto_boot is False:
-                log.warning("Cannot set root when motes are not booted! ")
-            else:
-                log.info("Setting DAG root...")
-                # make sure that the simulated motes are booted and the hardware motes have communicated there mote ID
-                time.sleep(1.5)
-                self.set_root(self.root)
 
     @staticmethod
     def cleanup_temporary_files(files):

--- a/openvisualizer/main.py
+++ b/openvisualizer/main.py
@@ -215,6 +215,7 @@ class OpenVisualizerServer(SimpleXMLRPCServer, EventBusClient):
                 iotlab_passwd=iotlab_passwd,
                 iotlab_key_file=iotlab_key_file,
                 iotlab_key_pas=iotlab_key_pas,
+                baudrate=baudrate
                 )
         elif testbed_motes:
             motes_finder = testbedmoteprobe.OpentestbedMoteFinder(mqtt_broker)

--- a/openvisualizer/motehandler/moteprobe/serialmoteprobe.py
+++ b/openvisualizer/motehandler/moteprobe/serialmoteprobe.py
@@ -88,10 +88,11 @@ class SerialMoteProbe(MoteProbe):
 
     def _send_data(self, data):
         hdlc_data = self.hdlc.hdlcify(data)
-        bytes_written = 0
-        self._serial.flush()
-        while bytes_written != len(bytearray(hdlc_data)):
-            bytes_written += self._serial.write(hdlc_data)
+        hdlc_len = len(bytearray(hdlc_data))
+        sent = 0
+        while not self.quit and sent != hdlc_len:
+            rem = hdlc_len - sent
+            sent += self._serial.write(hdlc_data[sent:sent + rem])
 
     def _rcv_data(self, rx_bytes=1):
         data = self._serial.read(rx_bytes)

--- a/tests/scripts/serialtester_cli.py
+++ b/tests/scripts/serialtester_cli.py
@@ -3,16 +3,19 @@
 import logging
 import time
 
+import os
+import signal
 import click
 import coloredlogs
 
 from openvisualizer.motehandler.moteprobe import serialmoteprobe
 from openvisualizer.motehandler.moteprobe.serialmoteprobe import SerialMoteProbe
+from openvisualizer.motehandler.moteprobe.iotlabmoteprobe import IotlabMoteProbe
 from openvisualizer.motehandler.moteprobe.serialtester import SerialTester
 
 for logger in [logging.getLogger(__name__), serialmoteprobe.log]:
     coloredlogs.install(logger=logger, fmt="%(asctime)s [%(name)s:%(levelname)s] %(message)s", datefmt="%H:%m:%S",
-                        level='WARNING')
+                        level='ERROR')
 
 
 def serialtest_tracer(msg):
@@ -25,72 +28,83 @@ def serialtest_tracer(msg):
 
 
 @click.command()
-@click.argument('port', required=True, nargs=1, type=str)
+@click.option('--port', default='/dev/ttyUSB1', show_default=True, help='Serial port to test')
 @click.option('--baudrate', default=115200, show_default=True, help='Specify baudrate')
 @click.option('--verbose', is_flag=True, help='Enable debug output from serialtester')
+@click.option('--iotlab-mote', help='Iotlab mote')
+@click.option('--iotlab-user', default=None, help='Iotlab account user')
+@click.option( '--iotlab-passwd', default=None, help='Iotlab account password')
 @click.option('-r', '--runs', default=100, show_default=True, help='Test iterations')
 @click.option('-l', '--pktlen', default=100, show_default=True, help='Length of the echo packet')
 @click.option('-t', '--timeout', default=2, show_default=True, help='Timeout on echo reception (in seconds)')
-def cli(port, baudrate, verbose, runs, pktlen, timeout):
+def cli(port, baudrate, iotlab_mote, iotlab_user, iotlab_passwd,
+        verbose, runs, pktlen, timeout):
     """ Serial Tester tool """
 
     click.secho("Serial Tester Script...", bold=True)
 
-    smp = SerialMoteProbe(port=port, baudrate=baudrate)
+    moteprobe = None
 
-    while smp.serial is None:
-        time.sleep(0.1)
+    try:
+        if iotlab_mote:
+            moteprobe = IotlabMoteProbe(
+                iotlab_mote=iotlab_mote,
+                iotlab_user=iotlab_user,
+                iotlab_passwd=iotlab_passwd
+                )
+            while moteprobe._socket is None:
+                time.sleep(0.1)
+        else:
+            moteprobe = SerialMoteProbe(port=port, baudrate=baudrate)
+            while moteprobe._serial is None:
+                time.sleep(0.1)
 
-    logger.info("initialized serial object")
+        logger.info("initialized serial object")
 
-    tester = SerialTester(smp)
+        tester = SerialTester(moteprobe)
 
-    if verbose:
-        tester.set_trace(serialtest_tracer)
+        if verbose:
+            tester.set_trace(serialtest_tracer)
 
-    tester.set_num_test_pkt(runs)
-    tester.set_test_pkt_length(pktlen)
-    tester.set_timeout(timeout)
+        tester.set_num_test_pkt(runs)
+        tester.set_test_pkt_length(pktlen)
+        tester.set_timeout(timeout)
 
-    click.secho("\nTest Setup:", bold=True)
-    click.secho("----------------")
-    click.secho("Iterations: {:>6}".format(runs))
-    click.secho("Packet length: {:>3}".format(pktlen))
-    click.secho("Echo timeout: {:>4}".format(timeout))
+        click.secho("\nTest Setup:", bold=True)
+        click.secho("----------------")
+        click.secho("Iterations: {:>6}".format(runs))
+        click.secho("Packet length: {:>3}".format(pktlen))
+        click.secho("Echo timeout: {:>4}".format(timeout))
 
-    click.secho("\nTest Progress:\n")
-    # start test
-    if verbose:
-        tester.test(blocking=True)
-    else:
-        tester.test(blocking=False)
+        click.secho("\nTest Progress:\n")
+        # start test
+        if verbose:
+            tester.test(blocking=True)
+        else:
+            tester.test(blocking=False)
 
-        with click.progressbar(range(runs)) as bar:
-            for x in bar:
-                while tester.stats['numOk'] < x:
-                    time.sleep(0.2)
+            with click.progressbar(range(runs)) as bar:
+                for x in bar:
+                    while tester.stats['numOk'] < x:
+                        time.sleep(0.2)
 
-    time.sleep(0.5)
-    res = tester.get_stats()
-    click.secho("\n\nTest Statistics:", bold=True)
-    click.secho("----------------")
-    click.secho("Pkts send: {:>8}".format(res['numSent']))
-    click.secho("Echo success: {:>5}".format(res['numOk']), fg='green')
-    click.secho("Echo timeout: {:>5}".format(res['numTimeout']), fg='yellow')
-    click.secho("Echo corrupted: {:>3}".format(res['numCorrupted']), fg='red')
-
-    click.secho("\nKill with Ctrl-C.\n")
-
-    while True:
-        try:
-            time.sleep(0.5)
-        except KeyboardInterrupt:
-            smp.close()
-            smp.join()
-            break
-
-    logger.info("quitting script")
+        time.sleep(0.5)
+        res = tester.get_stats()
+        click.secho("\n\nTest Statistics:", bold=True)
+        click.secho("----------------")
+        click.secho("Pkts send: {:>8}".format(res['numSent']))
+        click.secho("Echo success: {:>5}".format(res['numOk']), fg='green')
+        click.secho("Echo timeout: {:>5}".format(res['numTimeout']), fg='yellow')
+        click.secho("Echo corrupted: {:>3}".format(res['numCorrupted']), fg='red')
+    except KeyboardInterrupt:
+        click.secho("\nKeyboard Interrupt, forced exit!")
+    finally:
+        click.secho("\nexiting...\n")
+        if moteprobe:
+            moteprobe.close()
+            moteprobe.join()
+        os.kill(os.getpid(), signal.SIGTERM)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     cli()

--- a/tests/scripts/serialtester_cli.py
+++ b/tests/scripts/serialtester_cli.py
@@ -50,7 +50,8 @@ def cli(port, baudrate, iotlab_mote, iotlab_user, iotlab_passwd,
             moteprobe = IotlabMoteProbe(
                 iotlab_mote=iotlab_mote,
                 iotlab_user=iotlab_user,
-                iotlab_passwd=iotlab_passwd
+                iotlab_passwd=iotlab_passwd,
+                baudrate=baudrate,
                 )
             while moteprobe._socket is None:
                 time.sleep(0.1)


### PR DESCRIPTION
This PR adds support for `iotlab-a8-m3` boards usage. It also adds a XonXoff implementation for iotlab access.

Some fixes have been added in this PR as well:

- gracefully ignore invalid --root node 2b7f7ab
- handle forced exit during openv-serial, run as script as well as adding iotlab support
51a4c6b
- if not all bytes are written attempt to send only the ones missing cdfc2c8


`serialtester` still works on an `opnemote-b`

```
python tests/scripts/serialtester_cli.py 
Serial Tester Script...

Test Setup:
----------------
Iterations:    100
Packet length: 100
Echo timeout:    2

Test Progress:

  [####################################]  100%          


Test Statistics:
----------------
Pkts send:      100
Echo success:   100
Echo timeout:     0
Echo corrupted:   0

exiting...
```

Can now connect to a8-m3

```
openv-server --iotlab-motes a8-100.saclay.iot-lab.info m3-101.grenoble.iot-lab.info --baudrate=500000

 ___                 _ _ _  ___  _ _ 
| . | ___  ___ ._ _ | | | |/ __>| \ |
| | || . \/ ._>| ' || | | |\__ \|   |
`___'|  _/\___.|_|_||__/_/ <___/|_\_|
     |_|                  openwsn.org

10:37:20 [OpenVisualizerServer:VERBOSE] Loading logging configuration: config/logging.conf
10:37:20 [OpenVisualizerServer:INFO] Initializing OV Server with options:
	- host address server     = localhost
	- port number server      = 9000
	- firmware path           = /home/francisco/workspace/openwsn/openwsn-fw-riot/
	- use page zero           = False
	- use VCD logger          = False
	- baudrates to probe      = ['500000']
10:37:22 [MoteProbe:SUCCESS] a8-100.saclay.iot-lab.info Ok.
10:37:23 [MoteProbe:SUCCESS] m3-101.grenoble.iot-lab.info Ok.
10:37:23 [MoteProbe:SUCCESS] Discovered following iotlab-motes: ['a8-100.saclay.iot-lab.info', 'm3-101.grenoble.iot-lab.info']
10:37:23 [OpenVisualizerServer:INFO] Extracting firmware definitions.
10:37:23 [Utils:VERBOSE] Extracting firmware component names
10:37:23 [Utils:VERBOSE] Extracting firmware log descriptions.
10:37:23 [Utils:VERBOSE] Extracting 6top return codes.
10:37:23 [Utils:VERBOSE] Extracting 6top states.
10:37:23 [OpenVisualizerServer:INFO] Starting RPC server
^C10:37:27 [MoteProbe:WARNING] a8-100.saclay.iot-lab.info; exit loop
10:37:27 [MoteProbe:WARNING] m3-101.grenoble.iot-lab.info; exit loop
```