### PR TITLE
Store logs and data files in OS-appropriate locations

### DIFF
--- a/openvisualizer/__init__.py
+++ b/openvisualizer/__init__.py
@@ -1,6 +1,8 @@
 VERSION = '2.0.0'
 
 PACKAGE_NAME = 'openvisualizer'
+APPNAME = PACKAGE_NAME
+
 
 # cannot use os.path.join according to pkg_resources
 DEFAULT_LOGGING_CONF = '/'.join(("config", "logging.conf"))

--- a/openvisualizer/config/logging.conf
+++ b/openvisualizer/config/logging.conf
@@ -1,5 +1,3 @@
-# Note Expects 'logDir' passed in with location for file output.
-
 #============================ formatters ======================================
 
 [formatters]
@@ -17,12 +15,33 @@ datefmt=%H:%M:%S
 #============================ handlers ========================================
 
 [handlers]
-keys=std,console
+keys=std, console, errors, success, info
 
 [handler_std]
 class=handlers.RotatingFileHandler
 # args: filename, open mode, max file size, backup file count
-args=('openv-server.log', 'a', 2000000, 5)
+args=('%(log_dir)s/openv-server.log', 'a', 2000000, 5)
+formatter=std
+
+[handler_errors]
+class=logging.FileHandler
+# args: filename, open mode, max file size, backup file count
+args=('%(log_dir)s/openv-server-errors.log', 'w')
+level=ERROR
+formatter=std
+
+[handler_success]
+class=logging.FileHandler
+# args: filename, open mode, max file size, backup file count
+args=('%(log_dir)s/openv-server-success.log', 'w')
+level=SUCCESS
+formatter=std
+
+[handler_info]
+class=logging.FileHandler
+# args: filename, open mode, max file size, backup file count
+args=('%(log_dir)s/openv-server-info.log', 'w')
+level=INFO
 formatter=std
 
 [handler_console]
@@ -134,7 +153,7 @@ qualname=Parser
 
 [logger_ParserLogs]
 level=VERBOSE
-handlers=std, console
+handlers=std, console, errors, success, info
 propagate=0
 qualname=ParserLogs
 

--- a/openvisualizer/jrc/jrc.py
+++ b/openvisualizer/jrc/jrc.py
@@ -101,7 +101,7 @@ class ContextHandler(object):
             "recipientID": recipient_id,
             "senderID": sender_id,
             "replayWindow": [0],
-            "sequenceNumber": 0
+            "sequenceNumber": 0,
         }
 
         with open(file_path, "w") as context_file:

--- a/openvisualizer/rpl/rpl.py
+++ b/openvisualizer/rpl/rpl.py
@@ -14,7 +14,10 @@ Module which coordinates rpl DIO and DAO messages.
 """
 
 import logging
+import os
 import threading
+
+from appdirs import user_data_dir
 
 from openvisualizer.eventbus import eventbusclient
 from openvisualizer.rpl import sourceroute
@@ -270,7 +273,7 @@ class RPL(eventbusclient.EventBusClient):
             self.parents_dao_seq[node].append(dao_header['RPL_DAO_Sequence'])
 
         try:
-            with open('dao_sequence.txt', 'a') as f:
+            with open(os.path.join(user_data_dir('openvisualizer'), 'dao_sequence.txt'), 'a') as f:
                 f.write(str(self.parents_dao_seq) + '\n')
         except IOError as err:
             log.error("Permission error: {}".format(err))

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,6 @@ ipaddr
 scapy
 sshtunnel
 iotlabcli
+appdirs
 pywin32; sys_platform == 'win32'
 colorama; sys_platform == 'win32'

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ exclude =
     .git,
     __pycache__
 
-max-line-length = 160
+max-line-length = 120
 
 disable =
     C813,


### PR DESCRIPTION
This PR makes sure that the log files and app data storage files, e.g., OSCORE security contexts, get stored in OS-dependent appropriate locations instead of just lingering around in the directory where the user invoked `openv-server` or `openv-client`.

Still needs to be tested on a Windows machine.