### PR TITLE
Fix iotlabcli version to <=3.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ blessed
 ipaddr
 scapy
 sshtunnel
-iotlabcli
+iotlabcli<=3.2.1
 appdirs
 pywin32; sys_platform == 'win32'
 colorama; sys_platform == 'win32'


### PR DESCRIPTION
`iotlabcli` drops support for Python 2 starting with version 3.3.0.

This change was tested by running `openv-server --help` nd `openv-client --help` on the commandline and making sure that these two commands run successfully.
Otherwise, the f-strings would have been incompatible with Python 2:
```
% openv-server --fw-path ~/Documents/openwsn-fw
Traceback (most recent call last):
  File "/Users/titan/opt/anaconda3/envs/openvisualizer/bin/openv-server", line 5, in <module>
    from openvisualizer.__main__ import main
  File "/Users/titan/opt/anaconda3/envs/openvisualizer/lib/python2.7/site-packages/openvisualizer/__main__.py", line 1, in <module>
    from openvisualizer.main import main
  File "/Users/titan/opt/anaconda3/envs/openvisualizer/lib/python2.7/site-packages/openvisualizer/main.py", line 28, in <module>
    from iotlabcli.parser import common
  File "/Users/titan/opt/anaconda3/envs/openvisualizer/lib/python2.7/site-packages/iotlabcli/__init__.py", line 24, in <module>
    from iotlabcli.auth import get_user_credentials
  File "/Users/titan/opt/anaconda3/envs/openvisualizer/lib/python2.7/site-packages/iotlabcli/auth.py", line 68
    pass_file.write(f'{username}:{enc_password}')
                                               ^
SyntaxError: invalid syntax
```