### PR TITLE
Probe all USB ports on Darwin

### DIFF
--- a/openvisualizer/motehandler/moteprobe/serialmoteprobe.py
+++ b/openvisualizer/motehandler/moteprobe/serialmoteprobe.py
@@ -130,7 +130,7 @@ class SerialMoteProbe(MoteProbe):
                     pass
             elif os.name == 'posix':
                 if platform.system() == 'Darwin':
-                    port_mask = ['/dev/tty.usbserial-*']
+                    port_mask = ['/dev/tty.usb*']
                 else:
                     port_mask = ['/dev/ttyUSB*']
                 for mask in port_mask:


### PR DESCRIPTION
This PR fixes `SerialMoteProbe` to probe all `/dev/tty.usb*` ports instead of only `/dev/tty.usbserial-*` ports.
When I connect an nRF52840-DK board to my M1 mac, the device shows up as `/dev/tty.usbmodem0006837436331`, which I can confirm belongs to the nRF board.

Example of a log after running `openv-server`:
```
23:38:05 WARNING Probing motes: ['/dev/tty.usbserial-100', '/dev/tty.usbserial-101', '/dev/tty.usbmodem0006837436331'] at baudrates [115200]
23:38:09 SUCCESS Discovered serial-port(s): ['/dev/tty.usbserial-101', '/dev/tty.usbmodem0006837436331']
23:38:09 INFO extracting firmware definitions.
23:38:09 VERBOSE extracting firmware component names
23:38:09 VERBOSE extracting firmware log descriptions.
23:38:09 VERBOSE extracting 6top return codes.
23:38:09 VERBOSE extracting 6top states.
23:38:09 SUCCESS connected to broker (argus.paris.inria.fr) for mote on port: /dev/tty.usbserial-101
23:38:10 INFO starting RPC server
23:38:10 SUCCESS connected to broker (argus.paris.inria.fr) for mote on port: /dev/tty.usbmodem0006837436331
```